### PR TITLE
Add tooltip to show full usernames

### DIFF
--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -155,6 +155,7 @@ div.column-header .mat-card-header {
 }
 
 .assignee-name {
+  display: inline-block;
   text-overflow: ellipsis;
   width: 80%;
   overflow: hidden;

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -155,7 +155,6 @@ div.column-header .mat-card-header {
 }
 
 .assignee-name {
-  display: inline-block;
   text-overflow: ellipsis;
   width: 80%;
   overflow: hidden;

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -42,7 +42,7 @@
         ></div>
         <mat-card-title>
           <div class="assignee-container">
-            <div class="assignee-name">
+            <div class="assignee-name" [matTooltip]="assignee.login" matTooltipPosition="above">
               {{ assignee.login }}
             </div>
             <div class="row-count count-margins" [matTooltip]="getIssueTooltip()" matTooltipPosition="above">


### PR DESCRIPTION
### Summary:

Fixes #[481]

#### Type of change:

(Delete where appropriate)

- ✨ New Feature/ Enhancement

### Changes Made:

- Added a tooltip to show full usernames, allows users to see full GitHub usernames for users whose names are too long and were truncated.

### Screenshots:

![image](https://github.com/user-attachments/assets/261eecfc-afbb-4f24-b073-c3ed2ad9a830)

### Proposed Commit Message:

```
Add tooltip to show full usernames

There is no way to see the user's full username if it is too long
and gets truncated by the word limit.

This makes it difficult for a user to identify the assignee's full 
GitHub username unless the user already knows their username.

Adding a tooltip to show the full GitHub username may help users
keep track of assignees better.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
