### PR TITLE
Add link to GitHub profile on header card

### DIFF
--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -160,6 +160,14 @@ div.column-header .mat-card-header {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.assignee-name:hover {
+  color: #1a73e8;
 }
 
 :host ::ng-deep .pagination-hide-arrow .mat-paginator-navigation-previous {

--- a/src/app/issues-viewer/card-view/card-view.component.css
+++ b/src/app/issues-viewer/card-view/card-view.component.css
@@ -160,10 +160,7 @@ div.column-header .mat-card-header {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  color: inherit;
   cursor: pointer;
-  text-decoration: none;
-  transition: color 0.2s;
 }
 
 .assignee-name:hover {

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -30,7 +30,7 @@
 
 <ng-template #assigneeHeader let-assignee>
   <div class="column-header">
-    <mat-card>
+    <mat-card (click)="goToGithubProfile(assignee.login)" style="cursor: pointer">
       <mat-card-header [ngStyle]="{ height: '40px' }">
         <div
           mat-card-avatar

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -30,7 +30,7 @@
 
 <ng-template #assigneeHeader let-assignee>
   <div class="column-header">
-    <mat-card (click)="goToGithubProfile(assignee.login)" style="cursor: pointer">
+    <mat-card>
       <mat-card-header [ngStyle]="{ height: '40px' }">
         <div
           mat-card-avatar
@@ -42,7 +42,7 @@
         ></div>
         <mat-card-title>
           <div class="assignee-container">
-            <div class="assignee-name">
+            <div class="assignee-name" [matTooltip]="assignee.login" matTooltipPosition="above" (click)="goToGithubProfile(assignee.login)">
               {{ assignee.login }}
             </div>
             <div class="row-count count-margins" [matTooltip]="getIssueTooltip()" matTooltipPosition="above">

--- a/src/app/issues-viewer/card-view/card-view.component.html
+++ b/src/app/issues-viewer/card-view/card-view.component.html
@@ -42,7 +42,7 @@
         ></div>
         <mat-card-title>
           <div class="assignee-container">
-            <div class="assignee-name" [matTooltip]="assignee.login" matTooltipPosition="above" (click)="goToGithubProfile(assignee.login)">
+            <div class="assignee-name" (click)="goToGithubProfile(assignee.login)">
               {{ assignee.login }}
             </div>
             <div class="row-count count-margins" [matTooltip]="getIssueTooltip()" matTooltipPosition="above">

--- a/src/app/issues-viewer/card-view/card-view.component.ts
+++ b/src/app/issues-viewer/card-view/card-view.component.ts
@@ -145,4 +145,11 @@ export class CardViewComponent implements OnInit, AfterViewInit, OnDestroy, Filt
   getPrTooltip(): string {
     return this.issues.prCount + ' Pull Requests';
   }
+
+  goToGithubProfile(username: string): void {
+    if (username) {
+      const url = `https://github.com/${username}`;
+      window.open(url, '_blank'); // Opens in new tab
+    }
+  }
 }

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.css
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.css
@@ -41,6 +41,14 @@
   word-break: break-word;
 }
 
+.assignee-name {
+  cursor: pointer;
+}
+
+.assignee-name:hover {
+  color: #1a73e8;
+}
+
 .mat-card-avatar {
   height: 30px;
   width: 30px;

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.html
@@ -31,7 +31,11 @@
           'background-size': '30px'
         }"
       ></div>
-      <mat-card-title>{{ assignee.login }}</mat-card-title>
+      <mat-card-title>
+        <div class="assignee-name" (click)="goToGithubProfile(assignee.login)">
+          {{ assignee.login }}
+        </div>
+      </mat-card-title>
     </mar-card-header>
   </mat-card>
 </ng-template>

--- a/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
+++ b/src/app/issues-viewer/hidden-groups/hidden-groups.component.ts
@@ -35,4 +35,11 @@ export class HiddenGroupsComponent implements AfterViewInit {
         return this.defaultCardTemplate;
     }
   }
+
+  goToGithubProfile(username: string): void {
+    if (username) {
+      const url = `https://github.com/${username}`;
+      window.open(url, '_blank'); // Opens in new tab
+    }
+  }
 }


### PR DESCRIPTION
### Summary:

Fixes #482

#### Type of change:

- ✨ New Feature/ Enhancement

### Changes Made:

- Added link to direct users to assignee's GitHub profile on clicking username
- Changed assignee's GitHub username to blue on hover for clearer indication that it is a link
- Added links to hidden assignees' GitHub profiles in the hidden view

### Screenshots:

![Animation](https://github.com/user-attachments/assets/be9e39e2-4128-43d4-8a53-37dbef7fb967)

### Proposed Commit Message:

```
Add link to GitHub profile from header card

Users have to manually type the URL with the assignee's GitHub
username to check their profiles.

This makes it tedious for users to look at an assignee's GitHub
profile to track issues and PRs contributed or other stuff.

Adding a direct link to the assignee's GitHub profile helps users
check an assignee's profile more conveniently.
```

<details><summary>
<h3>Checklist:</h3>
</summary>

- [x] I have tested my changes thoroughly.
- [x] I have created tests for any new code files created in this PR or provided a link to a issue/PR that addresses this.
- [x] I have added or modified code comments to improve code readability where necessary.
- [x] I have updated the project's documentation as necessary.

</details>
